### PR TITLE
ダンプファイルのファイル名についてhexdigestで生成するように変更した

### DIFF
--- a/lib/seed/configuration.rb
+++ b/lib/seed/configuration.rb
@@ -1,3 +1,4 @@
+require 'digest'
 require 'active_record'
 
 module Seed
@@ -12,7 +13,7 @@ module Seed
     end
 
     def schema_version
-      @schema_version ||= ActiveRecord::Migrator.get_all_versions.hash
+      @schema_version ||= Digest::SHA256.hexdigest(ActiveRecord::Migrator.get_all_versions.sort.map(&:to_s).join(''))
     end
 
     def database_options


### PR DESCRIPTION
# 理由

```ActiveRecord::Migrator.get_all_versions``` で戻ってくる
マイグレーション済み日付の情報(配列)に対し、.hash メソッドをつけることで、
ファイル名を定義していたが、Object IDが毎度異なるようで、
その場合、.hashを呼び出すと異なるhash codeが返ってくる。

[Compute a hash-code for this array.](https://ruby-doc.org/core-2.4.0/Array.html#method-i-hash)

テスト時に、binding.pryを仕込みObject IDが異なる挙動を確認した。

- 1回目
```ruby
[7] pry(#<Seed::Configuration>)> ActiveRecord::Migrator.get_all_versions.object_id
=> 70227599201320
```

- 2回目

```ruby
[1] pry(#<Seed::Configuration>)> ActiveRecord::Migrator.get_all_versions.object_id
=> 70286610779840
```

配列の要素が呼び出し回数に変わらず同一でも、
Object IDが別なので、.hashが生成するhash codeが異なり、
以前作成していたdump fileが見つけられない状態であった。

# どんな変更を施したのか

- digest libraryを利用し、SHA256のHexdigestにて、一意のファイル名を生成するようにしました

# 動作確認

seed-snapshotに依存しているプロダクトに対し、Gemfileを以下のように変更。

```ruby
gem 'seed-snapshot', path: '../seed-snapshot'
```

bundle installを実行後、rspecを数回、実行し、db:migrateを実行していなければ
seedを再度importする処理を行わないようになるか確認した。

テスト例:

```
Randomized with seed 30151
Restored seed data by seed-snapshot gem.
....................................................................

Finished in 19.37 seconds (files took 6.04 seconds to load)
68 examples, 0 failures
```

:pray: 
