### PR TITLE
use hash of sorted array

### DIFF
--- a/lib/seed/configuration.rb
+++ b/lib/seed/configuration.rb
@@ -13,7 +13,7 @@ module Seed
     end
 
     def schema_version
-      @schema_version ||= Digest::SHA256.hexdigest(ActiveRecord::Migrator.get_all_versions.sort.map(&:to_s).join(''))
+      @schema_version ||= ActiveRecord::Migrator.get_all_versions.sort.hash
     end
 
     def database_options


### PR DESCRIPTION
schema_versionsの順序が不定であるため、hashが異なる場合があった。
sort済みのhash値を使うようにする