### PR TITLE
Add File::TRUNC when opening a manifest file

### DIFF
--- a/lib/seed/manifest.rb
+++ b/lib/seed/manifest.rb
@@ -19,7 +19,7 @@ module Seed
     def save
       @configuration.make_tmp_dir
 
-      open(self.manifest_path, File::WRONLY | File::CREAT) do |io|
+      open(self.manifest_path, File::WRONLY | File::CREAT | File::TRUNC) do |io|
         JSON.dump(self.current, io)
       end
     end


### PR DESCRIPTION
既にファイルが存在する場合、`File::WRONLY | File::CREAT` だと上書きされないようです。
なので `File::TRUNC` を追加し、ファイルオープン時に中身を消すようにします。

IO Open Mode についてはこちらに詳細があります。
http://ruby-doc.org/core-2.4.1/IO.html#method-c-new-label-IO+Open+Mode

ここで期待する挙動は `w` だと思うので、truncate が必要かと思います。