### PR TITLE
ignore_classesを使用時にDB名が渡されるよう修正

### DIFF
--- a/lib/seed/snapshot.rb
+++ b/lib/seed/snapshot.rb
@@ -62,8 +62,9 @@ module Seed
     end
 
     def tables(classes)
+      db = @configuration.database_options[:database]
       classes.map do |cls|
-        cls.table_name
+        "#{db}.#{cls.table_name}"
       end
     end
 


### PR DESCRIPTION
`SeedSnapshot.dump` に `ignore_classes` がありますが、これが動作しませんでした。

```rb
SeedSnapshot.dump(ignore_classes: [ActiveRecord::InternalMetadata])
```

（Rails 5で追加された `ar_internal_metadata` テーブルが残ってしまうため、これを無視する必要がありました）

```
Illegal use of option --ignore-table=<database>.<table> 
```

調査したところ、渡されたクラス名にdb名を付加していなかったために動作しなくなっていたようです。そのため、db名が渡されるよう修正しました。