### PR TITLE
Fix NoMethodError on Rails 5.2

### DIFF
--- a/lib/seed/configuration.rb
+++ b/lib/seed/configuration.rb
@@ -13,7 +13,7 @@ module Seed
     end
 
     def schema_version
-      @schema_version ||= Digest::SHA1.hexdigest(ActiveRecord::Migrator.get_all_versions.sort.join)
+      @schema_version ||= Digest::SHA1.hexdigest(get_all_versions.sort.join)
     end
 
     def database_options
@@ -32,6 +32,17 @@ module Seed
 
     def make_tmp_dir
       FileUtils.mkdir_p(base_path) unless File.exist?(base_path)
+    end
+
+    private
+
+    def get_all_versions
+      if ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new('5.2')
+        migration_paths = ::ActiveRecord::Migrator.migrations_paths
+        ::ActiveRecord::MigrationContext.new(migration_paths).get_all_versions
+      else
+        ::ActiveRecord::Migrator.get_all_versions
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

When I tried to use seed-snapshot gem with Rails 5.2.0 in our application, I found SeedSnapshot.restore raised NoMethodError. This is because ActiveRecord::Migrator.get_all_versions was moved into ActiveRecord::MigrationContext#get_all_versions by a refactoring at https://github.com/rails/rails/commit/a2827ec9811b5012e8e366011fd44c8eb53fc714.

To upgrade our application from Rails 5.1 to 5.2, we need to fix this problem.

## Solution

I modified Seed::Configuration#schema_version, where ActiveRecord::Migrator.get_all_versions is used,  so that it branches by ActiveRecord version. If the version is lower than 5.2.0, it will work in the same manner as before, but if it's not so, it will use ActiveRecord::MigrationContext#get_all_versions instead.