### PR TITLE
Add database name to value of mysqldump --ignore-table option.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 2.3.4
   - 2.4.1
   - ruby-head
+services:
+  - mysql
 env:
   - "AR_VERSION=4.2.8"
   - "AR_VERSION=4.2.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - "AR_VERSION=4.2.9"
   - "AR_VERSION=5.0.4"
   - "AR_VERSION=5.1.3"
+  - "AR_VERSION=5.2.3"
 sudo: false
 cache: bundler
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.3.4
-  - 2.4.1
-  - ruby-head
+  - 2.4
+  - 2.5
+  - 2.6
 services:
   - mysql
 env:

--- a/lib/seed/snapshot.rb
+++ b/lib/seed/snapshot.rb
@@ -69,7 +69,9 @@ module Seed
 
     def ignore_tables(classes)
       db = @configuration.database_options[:database]
-      tables(classes).push("#{db}.schema_migrations")
+
+      # mysqldump `--ignore-table` options require database name.
+      tables(classes).push('schema_migrations').map {|t| "#{db}.#{t}" }
     end
   end
 end

--- a/seed-snapshot.gemspec
+++ b/seed-snapshot.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'erubis'
-  spec.add_development_dependency 'mysql2', '>= 0.3', '< 0.4'
+  spec.add_development_dependency 'mysql2', '>= 0.4.4', '< 0.6.0'
   spec.add_runtime_dependency 'activerecord', '>= 4.2'
 end

--- a/test/cases/restore_test.rb
+++ b/test/cases/restore_test.rb
@@ -5,7 +5,7 @@ class RestoreTest < SeedSnapshot::TestCase
     SeedSnapshot.clean
 
     create_models
-    SeedSnapshot.dump(classes: [User, Book, Rent])
+    SeedSnapshot.dump(classes: [User, Book], ignore_classes: [Rent])
     destroy_models
   end
 
@@ -30,6 +30,6 @@ class RestoreTest < SeedSnapshot::TestCase
     SeedSnapshot.restore
     assert_equal User.count, 2
     assert_equal Book.count, 1
-    assert_equal Rent.count, 1
+    assert_equal Rent.count, 0
   end
 end


### PR DESCRIPTION
`SeedSnapshot.dump` with `ignore_classes` does not work because of generating invalid `mysqldump` command. The `--ignore-table` option requires `<database>.<table>` format but now `<database>.` is not prefixed.

#11 aim to resolve same issue. But the PR add unnecessary `<database>.` prefix to tables to dump, like `mysqldump -t my_database.users my_database.books ...`, and not worked.