### PR TITLE
:sparkles: Enable to use from mysql-client@8.

### DIFF
--- a/lib/seed/configuration.rb
+++ b/lib/seed/configuration.rb
@@ -16,6 +16,10 @@ module Seed
       @schema_version ||= Digest::SHA1.hexdigest(get_all_versions.sort.join)
     end
 
+    def client_version
+      @client_version ||= ActiveRecord::Base.connection.raw_connection.info[:version]
+    end
+
     def database_options
       @options ||= ActiveRecord::Base.connection.raw_connection.query_options
     end

--- a/lib/seed/mysql.rb
+++ b/lib/seed/mysql.rb
@@ -1,8 +1,16 @@
 module Seed
   class Mysql
-    def self.dump(file_path, username:, password:, host:, port:, database:, tables:, ignore_tables:)
+    def self.dump(file_path, username:, password:, host:, port:, database:, tables:, ignore_tables:, client_version:)
       host = 'localhost' unless host
-      cmd = "MYSQL_PWD=#{password} mysqldump -u #{username} -h #{host} #{database} -t #{allow_tables_option(tables)} #{ignore_tables_option(ignore_tables)} > #{file_path}"
+
+      additional_options =
+        if client_version.match?(/\A8/)
+          '--skip-column-statistics'
+        else
+          ''
+        end
+
+      cmd = "MYSQL_PWD=#{password} mysqldump -u #{username} -h #{host} #{database} -t #{allow_tables_option(tables)} #{ignore_tables_option(ignore_tables)} --no-tablespaces #{additional_options} > #{file_path}"
       system cmd
     end
 

--- a/lib/seed/snapshot.rb
+++ b/lib/seed/snapshot.rb
@@ -16,7 +16,8 @@ module Seed
         @configuration.current_version_path,
         options.merge({
           tables: tables(classes),
-          ignore_tables: ignore_tables(ignore_classes)
+          ignore_tables: ignore_tables(ignore_classes),
+          client_version: @configuration.client_version
         })
       )
     end


### PR DESCRIPTION
* `mysqldump` of mysql-client 8 try to dump `column_statistics` schema but not need the data from seed-snapshot usecases. So make to skip with `--skip-column-statistics` CLI option. ref: https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109
* from mysql-server 5.7.31, dumping `tablespaces` require the `PROCESS` privilege. Some environments (my case is on CircleCI `cimg/mysql:5.7` image) may fail to execute `mysqldump` by this. So make to skip with `--no-tablespaces` CLI option. ref: https://qiita.com/katzueno/items/29d812eb3aafdb23b0bb
