### PR TITLE
Ruby 2.7のキーワード引数の非互換警告を修正

### DIFF
--- a/lib/seed/snapshot.rb
+++ b/lib/seed/snapshot.rb
@@ -14,7 +14,7 @@ module Seed
 
       Mysql.dump(
         @configuration.current_version_path,
-        options.merge({
+        **options.merge({
           tables: tables(classes),
           ignore_tables: ignore_tables(ignore_classes),
           client_version: @configuration.client_version
@@ -32,7 +32,7 @@ module Seed
 
       Mysql.restore(
         @configuration.current_version_path,
-        options
+        **options
       )
     end
 


### PR DESCRIPTION
Ruby 2.7で使用すると以下のような警告が出るのを修正しました

```
vendor/bundle/ruby/2.7.0/bundler/gems/seed-snapshot-4983b8c983a8/lib/seed/snapshot.rb:15: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
vendor/bundle/ruby/2.7.0/bundler/gems/seed-snapshot-4983b8c983a8/lib/seed/mysql.rb:3: warning: The called method `dump' is defined here
```