### PR TITLE
fix: Consider DB connection port.

### DIFF
--- a/lib/seed/mysql.rb
+++ b/lib/seed/mysql.rb
@@ -10,13 +10,13 @@ module Seed
           ''
         end
 
-      cmd = "MYSQL_PWD=#{password} mysqldump -u #{username} -h #{host} #{database} -t #{allow_tables_option(tables)} #{ignore_tables_option(ignore_tables)} --no-tablespaces #{additional_options} > #{file_path}"
+      cmd = "MYSQL_PWD=#{password} mysqldump -u #{username} -h #{host} -P #{port} #{database} -t #{allow_tables_option(tables)} #{ignore_tables_option(ignore_tables)} --no-tablespaces #{additional_options} > #{file_path}"
       system cmd
     end
 
     def self.restore(file_path, username:, password:, host:, port:, database:)
       host = 'localhost' unless host
-      cmd = "MYSQL_PWD=#{password} mysql -u #{username} -h #{host} #{database} < #{file_path}"
+      cmd = "MYSQL_PWD=#{password} mysql -u #{username} -h #{host} -P #{port} #{database} < #{file_path}"
       system cmd
     end
 


### PR DESCRIPTION
Long time no see~

If MySQL is running on a port other than 3306, `dump` and `restore` will fail.
I fixed by adding `-P` option to `mysql` client command.

Tests for this changes are little bit hard to prepare env so please for give me to skip this 🙏 