### PR TITLE
Support mysql2 0.5.7

### DIFF
--- a/lib/seed/configuration.rb
+++ b/lib/seed/configuration.rb
@@ -21,7 +21,7 @@ module Seed
     end
 
     def database_options
-      @options ||= ActiveRecord::Base.connection.raw_connection.query_options
+      @options ||= ActiveRecord::Base.connection_db_config.configuration_hash
     end
 
     # ${Rails.root}/tmp/dump

--- a/test/cases/db_config.rb
+++ b/test/cases/db_config.rb
@@ -6,6 +6,24 @@ require 'seed-snapshot'
 require 'support/config'
 require 'support/connection'
 
+# create database if it doesn't exist
+def create_database_if_not_exists
+  ARTest.connection_config.each do |_, config|
+    begin
+      ActiveRecord::Base.establish_connection(config.except('database'))
+      ActiveRecord::Base.connection.create_database(config['database'], charset: config['encoding'], collation: config['collation'])
+    rescue ActiveRecord::DatabaseAlreadyExists
+      # Database already exists, nothing to do
+    rescue => e
+      raise "Failed to create database '#{config['database']}': #{e.message}"
+    ensure
+      ActiveRecord::Base.remove_connection
+    end
+  end
+end
+
+create_database_if_not_exists
+
 # connect to the database
 ARTest.connect
 


### PR DESCRIPTION
- mysql2 の 0.5.7 で raw_connection.query_option から password が削除されたのでconnection_db_config から取得するように変更
  - ref: https://github.com/brianmario/mysql2/pull/1334
- connection_db_config はサポートしている activerecord 7.0 から存在する
  - https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/connection_handling.rb#L304